### PR TITLE
Buug curb 5008 no way to log in to another account on ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - with new customer accounts, logging out and back in on iOS wouldn't present the login form to a customer but just log
   them back in with the email address they had been logged in before
 
+### Changed
+- BREAKING: requires PWA 7.27.0 or higher
+
 ## [2.3.0] - 2025-04-30
 ### Added
 - support for B2B carts using the first company contact and location of a customer if set (requires new customer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- with new customer accounts, logging out and back in on iOS wouldn't present the login form to a customer but just log
+  them back in with the email address they had been logged in before
+
 ## [2.3.0] - 2025-04-30
 ### Added
 - support for B2B carts using the first company contact and location of a customer if set (requires new customer

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1-beta.1",
+  "version": "2.3.1-beta.2",
   "id": "@shopgate/shopify-user",
   "trusted": true,
   "configuration": {

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.0",
+  "version": "2.3.1-beta.1",
   "id": "@shopgate/shopify-user",
   "trusted": true,
   "configuration": {

--- a/frontend/headlessLogin/actions.js
+++ b/frontend/headlessLogin/actions.js
@@ -57,7 +57,7 @@ export const headlessLogout = () => async (dispatch) => {
   }
 
   try {
-    const response = await new HttpRequest(logoutUrl).dispatch();
+    const response = await new HttpRequest(logoutUrl).setHeaders({ accept: 'text/html' }).dispatch();
 
     logger.warn('Shopify logout request response', response);
   } catch (e) {

--- a/frontend/headlessLogin/actions.js
+++ b/frontend/headlessLogin/actions.js
@@ -57,7 +57,7 @@ export const headlessLogout = () => async (dispatch) => {
   }
 
   try {
-    // Shopify declines any other content type and the iOS app will automatically send application/x-www-form-urlencoded if nothing else was set
+    // Shopify declines any other content type and the iOS app will automatically send */* if nothing else was set (yes, that's also gonna be declined)
     const response = await new HttpRequest(logoutUrl).setHeaders({ accept: 'text/html' }).dispatch();
 
     logger.warn('Shopify logout request response', response);

--- a/frontend/headlessLogin/actions.js
+++ b/frontend/headlessLogin/actions.js
@@ -57,6 +57,7 @@ export const headlessLogout = () => async (dispatch) => {
   }
 
   try {
+    // Shopify declines any other content type and the iOS app will automatically send application/x-www-form-urlencoded if nothing else was set
     const response = await new HttpRequest(logoutUrl).setHeaders({ accept: 'text/html' }).dispatch();
 
     logger.warn('Shopify logout request response', response);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,8 @@
     "@shopgate/engage": ">= 6.19.8"
   },
   "dependencies": {
-    "@shopgate/pwa-core": "^6.19.8",
-    "@shopgate/pwa-webcheckout-shopify": "^6.19.8",
+    "@shopgate/pwa-core": "^7.27.0-beta.2",
+    "@shopgate/pwa-webcheckout-shopify": "^7.27.0-beta.2",
     "react": "^16.8.2"
   }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Sets an `accept: text/plain` header to be sent when requesting the Shopify headless logout URL. On iOS, the app used to send `accept: */*` which is rejected with a 406 by Shopify, stating only HTML is allowed. On Android the header was omitted, which also worked.

The effect if the 406 being returned is that the customer is not logged out properly. Next time they try to log in they won't be presented with the forms asking for email address and otp. They'll just be logged in with the email address they had been logged in before.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md