### PR TITLE
Curb 5385 adding bundles to cart fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- using Shopify old customer accounts and the cart extension with a headless storefront API token broke customer logins
 
 ## [3.0.1] - 2025-07-31
 ### Fixed

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.1",
+  "version": "3.0.2-beta.1",
   "id": "@shopgate/shopify-user",
   "trusted": true,
   "configuration": {
@@ -78,6 +78,17 @@
           "service": "config",
           "path": "/v1/shop/%(shopId)s/checkout_web_checkout_shopify?parsed=true",
           "key": "value.backend.shopifyHeadlessApi.loginRedirectUrl"
+      }
+    },
+    "shopifyHeadlessStorefrontAccessToken": {
+      "type": "bigApi",
+      "destination" : "backend",
+      "default": null,
+      "params": {
+        "method":  "GET",
+        "service": "config",
+        "path": "/v1/shop/%(shopId)s/checkout_web_checkout_shopify?parsed=true",
+        "key": "value.backend.shopifyHeadlessStorefrontAccessToken"
       }
     },
     "shopifyLoginStrategy": {

--- a/extension/lib/ShopifyApiFactory.js
+++ b/extension/lib/ShopifyApiFactory.js
@@ -74,7 +74,8 @@ module.exports = class {
       context.storage.user,
       adminApi,
       headlessAuthApi,
-      context.log
+      context.log,
+      context.config.shopifyHeadlessStorefrontAccessToken
     )
   }
 }

--- a/extension/lib/ShopifyApiTokenManager.js
+++ b/extension/lib/ShopifyApiTokenManager.js
@@ -8,14 +8,16 @@ module.exports = class ShopifyApiTokenManager {
    * @param {ShopifyAdminApi} adminApi
    * @param {ShopifyHeadlessAuthApi} headlessAuthApi
    * @param {SDKContextLog} logger
+   * @param {string} headlessStorefrontAccessToken
    */
-  constructor (extensionStorage, userStorage, adminApi, headlessAuthApi, logger) {
+  constructor (extensionStorage, userStorage, adminApi, headlessAuthApi, logger, headlessStorefrontAccessToken) {
     this.extensionStorage = extensionStorage
     this.userStorage = userStorage
     this.adminApi = adminApi
     this.headlessAuthApi = headlessAuthApi
     this.log = logger
     this.userStorageNames = ['shopifyCartId', 'customerAccessToken', 'customerAccountApiAccessToken', 'headlessAuthApiAccessToken', 'userData']
+    this.headlessStorefrontAccessToken = headlessStorefrontAccessToken
   }
 
   /**
@@ -26,6 +28,9 @@ module.exports = class ShopifyApiTokenManager {
    * @returns {Promise<string>}
    */
   async getStorefrontApiAccessToken (useCache = true, accessTokenTitle = 'Web Checkout Storefront Access Token') {
+    // if a headless Storefront API access token is configured, always use that
+    if (this.headlessStorefrontAccessToken) return this.headlessStorefrontAccessToken
+
     let token
 
     if (useCache) token = await this.extensionStorage.get('storefrontAccessToken')

--- a/extension/typedef.js
+++ b/extension/typedef.js
@@ -11,6 +11,7 @@
  * @typedef {Object} ExtensionConfig
  * @property {string} shopifyShopAlias
  * @property {string} shopifyAccessToken
+ * @property {string} shopifyHeadlessStorefrontAccessToken
  * @property {string} shopifyShopId
  * @property {string} shopifyHeadlessApiClientId
  * @property {string} shopifyHeadlessApiClientSecret


### PR DESCRIPTION
## Description

Uses the Shopify headless storefront API access token if set up, as does the shopify-cart extension. Solves login issues when using old Shopify customer accounts in combination with a headless storefront.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md