### PR TITLE
CURB-6105: Introduce guest checkout link portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- portals `page.login.guest-checkout-link.before`, `page.login.guest-checkout-link` (wrapper) and
+  `page.login.guest-checkout-link.after` around the guest checkout link, so it can be extended or hidden
+  (e.g. depending on the cart contents) without overriding the whole login page
 
 ## [3.1.3] - 2026-01-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [3.2.0] - 2026-07-21
 ### Added
 - portals `page.login.guest-checkout-link.before`, `page.login.guest-checkout-link` (wrapper) and
   `page.login.guest-checkout-link.after` around the guest checkout link, so it can be extended or hidden
@@ -191,7 +193,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - user not logged in after registration in web checkout
 
-[Unreleased]: https://github.com/shopgate/ext-shopify-user/compare/v3.1.3...HEAD
+[Unreleased]: https://github.com/shopgate/ext-shopify-user/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/shopgate/ext-shopify-user/compare/v3.1.3...v3.2.0
 [3.1.3]: https://github.com/shopgate/ext-shopify-user/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/shopgate/ext-shopify-user/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/shopgate/ext-shopify-user/compare/v3.1.0...v3.1.1

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.3",
+  "version": "3.2.0",
   "id": "@shopgate/shopify-user",
   "trusted": true,
   "configuration": {

--- a/frontend/constants/portals.js
+++ b/frontend/constants/portals.js
@@ -1,0 +1,1 @@
+export const GUEST_CHECKOUT_LINK = 'page.login.guest-checkout-link';

--- a/frontend/portals/GuestCheckoutLink/index.jsx
+++ b/frontend/portals/GuestCheckoutLink/index.jsx
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 import { RouteContext } from '@shopgate/pwa-common/context';
 import I18n from '@shopgate/pwa-common/components/I18n';
 import Link from '@shopgate/pwa-common/components/Link';
+import SurroundPortals from '@shopgate/pwa-common/components/SurroundPortals';
 import { CHECKOUT_PATH } from '@shopgate/pwa-common/constants/RoutePaths';
 import styles from './style';
 import { CHECKOUT_GUEST_PATH } from './../../constants/RoutePaths';
+import { GUEST_CHECKOUT_LINK } from '../../constants/portals';
 import config from '../../config';
 
 /**
@@ -27,12 +29,14 @@ const GuestCheckoutLink = ({ visible, redirectLocation }) => {
     return null;
   }
   return (
-    <div className={styles.container}>
-      <I18n.Text string="checkout.or" className={styles.or} />
-      <Link href={CHECKOUT_GUEST_PATH} className={styles.guestCheckout}>
-        <I18n.Text string="checkout.continue_as_guest" />.
-      </Link>
-    </div>
+    <SurroundPortals portalName={GUEST_CHECKOUT_LINK}>
+      <div className={styles.container}>
+        <I18n.Text string="checkout.or" className={styles.or} />
+        <Link href={CHECKOUT_GUEST_PATH} className={styles.guestCheckout}>
+          <I18n.Text string="checkout.continue_as_guest" />.
+        </Link>
+      </div>
+    </SurroundPortals>
   );
 };
 


### PR DESCRIPTION
## Summary

Introduces dedicated portals around the guest checkout link on the login page, so external developers can extend — or hide — the link (e.g. depending on the cart contents) without having to override the whole login page.

Jira: [CURB-6105](https://jira.shopgate.guru/browse/CURB-6105)

## Changes

- Wrap the rendered guest checkout block in `SurroundPortals`, which exposes three new portals:
  - `page.login.guest-checkout-link.before`
  - `page.login.guest-checkout-link` (wrapper — receives the guest checkout block as `children`)
  - `page.login.guest-checkout-link.after`
- Add the portal name constant in `frontend/constants/portals.js`.
- Update `CHANGELOG.md`.

## How to hide the link

An extension registers a component against the wrapper portal `page.login.guest-checkout-link`. It receives the original guest checkout block — the `checkout.or` separator plus the "continue as guest" link — via `children` and can decide, based on the cart, whether to render it or return `null`. The whole block (not just the link) is wrapped on purpose, so hiding it does not leave a dangling "or" separator behind.

## Acceptance criteria

- [x] new before, after + wrapper portal added for `page.login.guest-checkout-link`